### PR TITLE
Moved images to their own container for performance reasons.

### DIFF
--- a/LB.PhotoGalleries.Application/Constants.cs
+++ b/LB.PhotoGalleries.Application/Constants.cs
@@ -8,6 +8,7 @@
         internal static string DatabaseName => "PhotoGalleries";
         internal static string UsersContainerName => "Users";
         internal static string GalleriesContainerName => "Galleries";
+        internal static string ImagesContainerName => "Images";
         internal static string CategoriesContainerName => "Categories";
 
         /// <summary>

--- a/LB.PhotoGalleries.Application/Models/Gallery.cs
+++ b/LB.PhotoGalleries.Application/Models/Gallery.cs
@@ -23,10 +23,6 @@ namespace LB.PhotoGalleries.Application.Models
         /// </summary>
         public bool Active { get; set; }
         /// <summary>
-        /// The ordered list of images in the photo gallery.
-        /// </summary>
-        public Dictionary<int, Image> Images { get; set;}
-        /// <summary>
         /// Comments can be made by users against photo galleries themselves as well as on specific photos.
         /// </summary>
         public List<Comment> Comments { get; set; }
@@ -55,7 +51,6 @@ namespace LB.PhotoGalleries.Application.Models
         #region constructors
         public Gallery()
         {
-            Images = new Dictionary<int, Image>();
             Comments = new List<Comment>();
             Created = DateTime.Now;
         }

--- a/LB.PhotoGalleries.Application/Models/Image.cs
+++ b/LB.PhotoGalleries.Application/Models/Image.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace LB.PhotoGalleries.Application.Models
@@ -9,7 +10,13 @@ namespace LB.PhotoGalleries.Application.Models
         /// <summary>
         /// Will be the unique identifier of the image file in storage.
         /// </summary>
+        [JsonProperty("id")]
         public string Id { get; set; }
+        public string GalleryId { get; set; }
+        /// <summary>
+        /// The position of the image in the gallery.
+        /// </summary>
+        public int Position { get; set; }
         /// <summary>
         /// Descriptive name for the photo to be shown to users.
         /// </summary>
@@ -22,6 +29,10 @@ namespace LB.PhotoGalleries.Application.Models
         /// A credit for the photo, i.e. who took it.
         /// </summary>
         public string Credit { get; set; }
+        /// <summary>
+        /// When the image was created, not when the photo was originally captured.
+        /// </summary>
+        public DateTime Created { get; set; }
         /// <summary>
         /// When the photo was originally taken.
         /// </summary>
@@ -46,8 +57,21 @@ namespace LB.PhotoGalleries.Application.Models
         #region constructors
         public Image()
         {
+            Created = DateTime.Now;
             Comments = new List<Comment>();
             Tags = new List<string>();
+        }
+        #endregion
+
+        #region public methods
+        public bool IsValid()
+        {
+            if (string.IsNullOrEmpty(Id) ||
+                string.IsNullOrEmpty(Name) ||
+                string.IsNullOrEmpty(GalleryId))
+                return false;
+
+            return true;
         }
         #endregion
     }

--- a/LB.PhotoGalleries.Application/Server.cs
+++ b/LB.PhotoGalleries.Application/Server.cs
@@ -21,6 +21,7 @@ namespace LB.PhotoGalleries.Application
         public static Server Instance { get; }
         public CategoryServer Categories { get; internal set; }
         public GalleryServer Galleries { get; internal set; }
+        public ImageServer Images { get; internal set; }
         public UserServer Users { get; internal set; }
         /// <summary>
         /// Provides access to application configuration data, i.e. connection strings.
@@ -38,6 +39,7 @@ namespace LB.PhotoGalleries.Application
             {
                 Categories = new CategoryServer(),
                 Galleries = new GalleryServer(),
+                Images = new ImageServer(),
                 Users = new UserServer()
             };
         }
@@ -78,6 +80,10 @@ namespace LB.PhotoGalleries.Application
             var createdGalleriesContainerResponse = await Database.CreateContainerIfNotExistsAsync(Constants.GalleriesContainerName, "/CategoryId");
             var createdGalleriesContainer = createdGalleriesContainerResponse.StatusCode == HttpStatusCode.Created;
             Debug.WriteLine("Server.InitialiseDatabaseAsync: Created galleries container? " + createdGalleriesContainer);
+
+            var createdImagesContainerResponse = await Database.CreateContainerIfNotExistsAsync(Constants.ImagesContainerName, "/GalleryId");
+            var createdImagesContainer = createdImagesContainerResponse.StatusCode == HttpStatusCode.Created;
+            Debug.WriteLine("Server.InitialiseDatabaseAsync: Created images container? " + createdImagesContainer);
 
             var createdUsersContainerResponse = await Database.CreateContainerIfNotExistsAsync(Constants.UsersContainerName, "/PartitionKey");
             var createdUsersContainer = createdUsersContainerResponse.StatusCode == HttpStatusCode.Created;

--- a/LB.PhotoGalleries.Application/Servers/ImageServer.cs
+++ b/LB.PhotoGalleries.Application/Servers/ImageServer.cs
@@ -1,0 +1,158 @@
+﻿using Azure.Storage.Blobs;
+using LB.PhotoGalleries.Application.Models;
+using Microsoft.Azure.Cosmos;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace LB.PhotoGalleries.Application.Servers
+{
+    public class ImageServer
+    {
+        #region constructors
+        internal ImageServer()
+        {
+
+        }
+        #endregion
+
+        #region public methods
+        /// <summary>
+        /// Stores an uploaded file in the storage system and adds a supporting Image object to the database.
+        /// </summary>
+        /// <param name="galleryId">The gallery this image is going to be contained within.</param>
+        /// <param name="imageStream">The stream for the uploaded image file.</param>
+        /// <param name="filename">The original filename provided by the client.</param>
+        public async Task CreateImageAsync(string galleryId, Stream imageStream, string filename)
+        {
+            if (string.IsNullOrEmpty(galleryId))
+                throw new ArgumentNullException(nameof(galleryId));
+
+            if (imageStream == null)
+                throw new ArgumentNullException(nameof(imageStream));
+
+            if (string.IsNullOrEmpty(filename))
+                throw new ArgumentNullException(nameof(filename));
+
+            // create the Image object
+            var image = new Image
+            {
+                Id = Guid.NewGuid() + Path.GetExtension(filename).ToLower(),
+                Name = Path.GetFileNameWithoutExtension(filename),
+                GalleryId = galleryId
+            };
+
+            if (!image.IsValid())
+                throw new InvalidOperationException("Image would be invalid. PLease check all required properties are set.");
+
+            // upload the file to storage
+            var blobServiceClient = new BlobServiceClient(Server.Instance.Configuration["Storage:ConnectionString"]);
+            var blobContainerClient = blobServiceClient.GetBlobContainerClient(Constants.StorageOriginalContainerName);
+            await blobContainerClient.UploadBlobAsync(image.Id, imageStream);
+            imageStream.Close();
+
+            // create the database record
+            // work out what the new position should be .. skipping for now. can't think of a way to do this without lot's of queries
+
+            var container = Server.Instance.Database.GetContainer(Constants.ImagesContainerName);
+            var response = await container.CreateItemAsync(image, new PartitionKey(image.GalleryId));
+            Debug.WriteLine($"ImageServer.CreateImageAsync: Request charge: {response.RequestCharge}");
+        }
+
+        /// <summary>
+        /// Updates an Image in the database. Must be provided with a complete and recently queried from the database image to avoid losing other recent updates.
+        /// </summary>
+        public async Task UpdateImageAsync(Image image)
+        {
+            if (image == null)
+                throw new ArgumentNullException(nameof(image));
+
+            if (!image.IsValid())
+                throw new InvalidOperationException("Image is invalid. Please check all required properties are set.");
+
+            var container = Server.Instance.Database.GetContainer(Constants.ImagesContainerName);
+            var response = await container.ReplaceItemAsync(image, image.Id, new PartitionKey(image.GalleryId));
+            Debug.WriteLine($"ImageServer.UpdateImageAsync: Request charge: {response.RequestCharge}");
+        }
+
+        public async Task<List<Image>> GetGalleryImagesAsync(string galleryId)
+        {
+            const string query = "SELECT * FROM c WHERE c.GalleryId = @galleryId";
+            var queryDefinition = new QueryDefinition(query);
+            queryDefinition.WithParameter("@galleryId", galleryId);
+
+            var container = Server.Instance.Database.GetContainer(Constants.ImagesContainerName);
+            var queryResult = container.GetItemQueryIterator<Image>(queryDefinition);
+            double charge = 0;
+            var images = new List<Image>();
+
+            while (queryResult.HasMoreResults)
+            {
+                var results = await queryResult.ReadNextAsync();
+                images.AddRange(results);
+                charge += results.RequestCharge;
+            }
+
+            Debug.WriteLine($"ImageServer.GetGalleryImagesAsync: Found {images.Count} gallery images");
+            Debug.WriteLine($"ImageServer.GetGalleryImagesAsync: Total request charge: {charge}");
+
+            return images;
+        }
+        #endregion
+
+        #region internal methods
+        internal async Task<List<Image>> GetImagesUserHasCommentedOnAsync(string userId)
+        {
+            const string query = "SELECT * FROM c WHERE c.Comments.CreatedByUserId = @userId";
+            var queryDefinition = new QueryDefinition(query).WithParameter("@userId", userId);
+            return await GetImagesByQueryAsync(queryDefinition);
+        }
+
+        internal async Task<int> GetImagesScalarByQueryAsync(QueryDefinition queryDefinition, string queryColumnName)
+        {
+            if (queryDefinition == null)
+                throw new InvalidOperationException("queryDefinition is null");
+
+            var container = Server.Instance.Database.GetContainer(Constants.ImagesContainerName);
+            var result = container.GetItemQueryIterator<object>(queryDefinition);
+
+            var count = 0;
+            if (!result.HasMoreResults)
+                return count;
+
+            var resultSet = await result.ReadNextAsync();
+            Debug.WriteLine($"ImageServer.GetImagesScalarByQueryAsync: Query: {queryDefinition.QueryText}");
+            Debug.WriteLine($"ImageServer.GetImagesScalarByQueryAsync: Request charge: {resultSet.RequestCharge}");
+            foreach (JObject item in resultSet)
+                count = (int)item[queryColumnName];
+
+            return count;
+        }
+        #endregion
+
+        #region private methods
+        private static async Task<List<Image>> GetImagesByQueryAsync(QueryDefinition queryDefinition)
+        {
+            var container = Server.Instance.Database.GetContainer(Constants.ImagesContainerName);
+            var queryResult = container.GetItemQueryIterator<Image>(queryDefinition);
+            var users = new List<Image>();
+            double charge = 0;
+
+            while (queryResult.HasMoreResults)
+            {
+                var resultSet = await queryResult.ReadNextAsync();
+                charge += resultSet.RequestCharge;
+                users.AddRange(resultSet);
+            }
+
+            Debug.WriteLine($"ImageServer.GetImagesByQueryAsync: Query: {queryDefinition.QueryText}");
+            Debug.WriteLine($"ImageServer.GetImagesByQueryAsync: Total request charge: {charge}");
+
+            return users;
+        }
+        #endregion
+    }
+}

--- a/LB.PhotoGalleries/Areas/Admin/Controllers/ImagesController.cs
+++ b/LB.PhotoGalleries/Areas/Admin/Controllers/ImagesController.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LB.PhotoGalleries.Areas.Admin.Controllers
+{
+    public class ImagesController : Controller
+    {
+        // GET: /admin/images
+        public ActionResult Index()
+        {
+            return View();
+        }
+
+        // GET: /admin/images/details/5
+        public ActionResult Details(string id)
+        {
+            return View();
+        }
+
+
+        // GET: /admin/images/edit/5
+        public ActionResult Edit(string id)
+        {
+            return View();
+        }
+
+        // POST: /admin/images/edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Edit(string id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: /admin/images/delete/5
+        public ActionResult Delete(string id)
+        {
+            return View();
+        }
+
+        // POST: /admin/images/delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(string id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+    }
+}

--- a/LB.PhotoGalleries/Areas/Admin/Views/Galleries/Edit.cshtml
+++ b/LB.PhotoGalleries/Areas/Admin/Views/Galleries/Edit.cshtml
@@ -1,8 +1,10 @@
 ﻿@using LB.PhotoGalleries.Application
+@using LB.PhotoGalleries.Application.Models
 @model LB.PhotoGalleries.Application.Models.Gallery
 @{
     ViewData["Title"] = "Edit Gallery";
     var error = (string)ViewData["error"];
+    var images = (List<Image>) ViewData["images"];
 }
 
 @section Styles {
@@ -107,7 +109,7 @@
 <div class="row">
     <div class="col">
         <div id="dropzone">
-            <form asp-action="Upload" asp-route-pk="@Model.CategoryId" asp-route-id="@Model.Id" class="dropzone needsclick dz-clickable" id="uploader">
+            <form asp-action="Upload" asp-route-id="@Model.Id" class="dropzone needsclick dz-clickable" id="uploader">
                 <div class="dz-message needsclick">
                     Drop files here or click to upload.<br>
                 </div>
@@ -117,9 +119,9 @@
 </div>
 
 <h2>Images</h2>
-<p>Count: @Model.Images.Count</p>
+<p>Count: @images.Count</p>
 
-@foreach (var image in Model.Images.OrderBy(i => i.Key).Select(q => q.Value))
+@foreach (var image in images.OrderBy(i => i.Position))
 {
     <img
         srcset="


### PR DESCRIPTION
Images have been moved into their own Cosmos DB container to improve performance in a few ways:

- Galleries would be big documents with images and their commons in so performing updates to galleries for each image upload is costly in terms of request unit and latency
- Images can be edited without needing to update large galleries, saving on request units
- Images can be replaced without needing to update large galleries, saving on request units