### PR TITLE
Feature: Adding Application Insights monitoring

### DIFF
--- a/LB.PhotoGalleries/LB.PhotoGalleries.csproj
+++ b/LB.PhotoGalleries/LB.PhotoGalleries.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Imageflow.Server.DiskCache" Version="0.5.3" />
     <PackageReference Include="Imageflow.Server.Storage.AzureBlob" Version="0.5.3" />
     <PackageReference Include="Mailjet.Api" Version="2.0.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />

--- a/LB.PhotoGalleries/Properties/serviceDependencies.json
+++ b/LB.PhotoGalleries/Properties/serviceDependencies.json
@@ -2,6 +2,9 @@
   "dependencies": {
     "secrets1": {
       "type": "secrets"
+    },
+    "appInsights1": {
+      "type": "appInsights"
     }
   }
 }

--- a/LB.PhotoGalleries/Properties/serviceDependencies.local.json
+++ b/LB.PhotoGalleries/Properties/serviceDependencies.local.json
@@ -2,6 +2,9 @@
   "dependencies": {
     "secrets1": {
       "type": "secrets.user"
+    },
+    "appInsights1": {
+      "type": "appInsights.sdk"
     }
   }
 }

--- a/LB.PhotoGalleries/Startup.cs
+++ b/LB.PhotoGalleries/Startup.cs
@@ -119,6 +119,7 @@ namespace LB.PhotoGalleries
             }
 
             services.AddHostedService<NotificationService>();
+            services.AddApplicationInsightsTelemetry();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Adding the configuration needed to enable basic Azure Application Insights server-side monitoring. Additional metric collection can be added as a later task.