### PR TITLE
Fix GetBackgroundImage logic

### DIFF
--- a/LB.PhotoGalleries/wwwroot/js/site.js
+++ b/LB.PhotoGalleries/wwwroot/js/site.js
@@ -49,8 +49,8 @@ function EncodeParamForUrl(parameter)
     // remove some characters
     parameter = parameter.replace(/\(|\)|'|@|#/g, "");
 
-    // replace hyphens with underscores
-    parameter = parameter.replace("-", "_");
+    // replace hyphens with underscores (all occurrences)
+    parameter = parameter.replace(/-/g, "_");
 
     // replace others with hyphens
     parameter = parameter.replace(/-| |\.|\//g, "-");
@@ -148,7 +148,7 @@ function IsMobileDevice() {
 }
 
 function GetBackgroundImage(image) {
-    if (image.LowResStorageId !== null) {
+    if (image?.Files?.SpecLowResId) {
         return `url(/dilr/${image.Files.SpecLowResId})`;
     }
     return null;


### PR DESCRIPTION
## Summary
- address typo in `GetBackgroundImage` so low-res thumbnails display correctly
- update JS encoding logic to replace all hyphens

## Testing
- `dotnet build --nologo`
- `dotnet test --nologo` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4427016c832687c16426281c01c2