### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A website to showcase the https://londonbikers.com photo galleries, both old and
 
 * Photo galleries
 * Gallery categories
-* Photom metadata display, i.e. camera settings
+* Photo metadata display, i.e. camera settings
 * Tag extraction from metadata
 * Tag generation via Azure Cognitive Services
 * Discourse API integration to allow cross-posting onto londonbikers.com


### PR DESCRIPTION
## Summary
- correct 'Photom metadata display' typo

## Testing
- `grep -n Photo metadata README.md`

------
https://chatgpt.com/codex/tasks/task_e_6841f3fe95d08326a647d2b6d4f1619e