### PR TITLE
Update stale GitHub Actions in workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,53 +19,45 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    # Required by codeql-action v3+ to upload results to the security tab.
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
     strategy:
       fail-fast: false
       matrix:
         # Override automatic language detection by changing the below list
-        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['csharp', 'javascript']
-        # Learn more...
-        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+        # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-language-identifiers
+        language: ['csharp', 'javascript-typescript']
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      uses: actions/checkout@v7
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+    # Autobuild compiles the C# projects, so the SDK must match the target
+    # framework. Keep this in step with the deploy workflows.
+    - name: Set up .NET
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v6
+      with:
+        dotnet-version: '9.0.x'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
+    # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+    # If this step fails, replace it with explicit build commands.
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/deploy-to-prod-server.yml
+++ b/.github/workflows/deploy-to-prod-server.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
 
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: '9.x.x'
+        dotnet-version: '9.0.x'
 
     - name: Build with dotnet
       run: dotnet build LB.PhotoGalleries/LB.PhotoGalleries.csproj --configuration Release
@@ -25,7 +25,7 @@ jobs:
       run: sudo rm -f /home/runner/work/PhotoGalleries/PhotoGalleries/LB.PhotoGalleries/bin/Release/net9.0/publish/appsettings*
 
     - name: Stop service before deployment
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.5
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}
@@ -40,7 +40,7 @@ jobs:
           fi
 
     - name: Copying files to server
-      uses: appleboy/scp-action@master
+      uses: appleboy/scp-action@v1.0.0
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}
@@ -53,7 +53,7 @@ jobs:
         overwrite: true
 
     - name: Restart service after deployment
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.5
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}

--- a/.github/workflows/deploy-to-test-server.yml
+++ b/.github/workflows/deploy-to-test-server.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v7
 
     - name: Set up .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: '9.x.x'
+        dotnet-version: '9.0.x'
 
     - name: Build with dotnet
       run: dotnet build LB.PhotoGalleries/LB.PhotoGalleries.csproj --configuration Release
@@ -27,7 +27,7 @@ jobs:
       run: sudo rm -f /home/runner/work/PhotoGalleries/PhotoGalleries/LB.PhotoGalleries/bin/Release/net9.0/publish/appsettings*
 
     - name: Stop service before deployment
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.5
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}
@@ -42,7 +42,7 @@ jobs:
           fi
 
     - name: Copying files to server
-      uses: appleboy/scp-action@master
+      uses: appleboy/scp-action@v1.0.0
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}
@@ -55,7 +55,7 @@ jobs:
         overwrite: true
 
     - name: Restart service after deployment
-      uses: appleboy/ssh-action@master
+      uses: appleboy/ssh-action@v1.2.5
       with:
         host: ${{ secrets.TEST_REMOTE_HOST }}
         port: ${{ secrets.TEST_PORT }}


### PR DESCRIPTION
Follow-up to #70. Worth merging before the .NET 10 upgrade, since CI is how you'd validate that work.

## The CodeQL workflow was disabled, not merely broken

Two separate problems, and only one of them is fixable in a PR:

1. **The workflow was in `disabled_inactivity` state.** GitHub auto-disables scheduled workflows after 60 days of repository inactivity, and the last run of anything in this repo was 2025-11-23. So CodeQL hadn't been failing — it hadn't been running at all. **Already re-enabled via `gh workflow enable`**, since no file change can do that.
2. **`github/codeql-action@v1` is deprecated and disabled by GitHub.** So even once re-enabled, it would have failed. Moved to `@v4`.

## Version bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@master`, `@v2` | `@v7` |
| `actions/setup-dotnet` | `@v1` | `@v6` |
| `github/codeql-action` | `@v1` | `@v4` |
| `appleboy/ssh-action` | `@master` | `@v1.2.5` |
| `appleboy/scp-action` | `@master` | `@v1.0.0` |

The three actions floating on `@master` were silently tracking upstream default branches — deployment behaviour could change with no commit in this repo. Now pinned to release tags. `checkout@v7` / `codeql-action@v4` match the current [official starter workflow](https://github.com/actions/starter-workflows/blob/main/code-scanning/codeql.yml).

## CodeQL workflow also needed

- **An explicit `permissions` block** (`actions: read`, `contents: read`, `security-events: write`) — required by codeql-action v3+ to upload results to the security tab. Without it the analyze step fails.
- **Removal of the legacy `git checkout HEAD^2` step** and its `fetch-depth: 2`. Modern CodeQL handles `pull_request` events directly and the manual checkout interferes.
- **`javascript` → `javascript-typescript`** language identifier.
- **An explicit `setup-dotnet` step for the `csharp` matrix leg.** Autobuild has to actually compile the projects, so the SDK needs to match the target framework rather than relying on whatever the runner image happens to ship. This is also the line to change for .NET 10.

Also normalised `dotnet-version` from `'9.x.x'` to the documented `'9.0.x'` form.

## Deliberately not changed

Both deploy workflows use `TEST_*` connection secrets, including the PROD one. **This is correct, not a bug** — the repository has no `PROD_REMOTE_HOST` or `PROD_SSH_KEY` secrets, only `PROD_REMOTE_DIR`, so TEST and PROD share a single VPS and are separated by directory and systemd service name. Flagging it because it reads like a bug at a glance.

## Verification

YAML parses clean for all three workflows; jobs and triggers unchanged. The CodeQL run on this PR is the real test of that half.

⚠️ The deploy workflows cannot be exercised without deploying, so `appleboy/*@master → pinned tag` and `setup-dotnet@v1 → @v6` carry residual risk on the next deploy. Worth running the TEST deploy first and confirming before a PROD dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)