### PR TITLE
Dependabot follow-up: suppress blocked packages, correct Mailjet finding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,33 @@ updates:
         update-types:
           - version-update:semver-major
 
+      # Packages deliberately held back. Each ignores *minor* updates only, so
+      # patch releases on the current line still raise PRs — a security fix
+      # shipped as e.g. Azure.Storage.Blobs 12.26.x would not be suppressed.
+      #
+      # Azure.Storage: 12.29.1/12.27.1 raise the Azure.Core floor to 1.55.0,
+      # which depends on Microsoft.Extensions.{Configuration,Hosting}
+      # .Abstractions 10.0.3 and drags the solution onto the .NET 10 package
+      # line (NU1605 package downgrade). Azure.Core 1.47.3 has no
+      # Microsoft.Extensions dependencies. Remove when moving to net10.0.
+      - dependency-name: "Azure.Storage.Blobs"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: "Azure.Storage.Queues"
+        update-types:
+          - version-update:semver-minor
+
+      # Imageflow.Net and Spectre.Console are 0.x, where a minor bump is
+      # breaking by convention. Imageflow also carries a native runtime.
+      # Remove once each has been smoke-tested against real image processing
+      # rather than a compile check.
+      - dependency-name: "Imageflow.Net"
+        update-types:
+          - version-update:semver-minor
+      - dependency-name: "Spectre.Console"
+        update-types:
+          - version-update:semver-minor
+
   # GitHub Actions used by the CodeQL and deployment workflows.
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,16 @@ updates:
         update-types:
           - version-update:semver-minor
 
+      # Microsoft.ApplicationInsights.AspNetCore 3.x pulls
+      # Microsoft.ApplicationInsights 3.x, which Serilog.Sinks.ApplicationInsights
+      # 5.0.1 excludes (requires >= 2.23.0 && < 3.0.0). This one is worth calling
+      # out: the mismatch surfaces as NU1608, a *warning*, so such a PR can pass
+      # CI while leaving a real runtime incompatibility. Remove when the Serilog
+      # sink supports App Insights 3.x.
+      - dependency-name: "Microsoft.ApplicationInsights.AspNetCore"
+        update-types:
+          - version-update:semver-major
+
       # Imageflow.Net and Spectre.Console are 0.x, where a minor bump is
       # breaking by convention. Imageflow also carries a native runtime.
       # Remove once each has been smoke-tested against real image processing

--- a/SECURITY-CHECKLIST.md
+++ b/SECURITY-CHECKLIST.md
@@ -195,15 +195,26 @@ pulls the patched `System.Text.Json` 6.0.11) and scanned clean, but Models was s
 every other project reaches Imageflow *through* Models, that one stale reference propagated
 GHSA-8g4q-xg66-9fp4 into seven projects.
 
-### ⚠️ Outstanding — no fix currently available
+### ⚠️ Outstanding — fix available via `Mailjet.Api` 4.x
 
 - [ ] `System.Net.Http` 4.3.0 — **High**, GHSA-7jgj-8wvc-jh57
 - [ ] `System.Text.RegularExpressions` 4.3.0 — **High**, GHSA-cmhx-cq75-c4mj
 
-Both arrive via `Mailjet.Api` 3.0.1 → `NETStandard.Library` 1.6.1. 3.0.1 is the latest Mailjet.Api, so
-there is no upgrade path — resolving these means replacing the Mailjet client library. On `net9.0` both
-assemblies resolve to the shared framework at runtime, so practical exposure is low, but the audit will
-continue to flag them.
+Both arrive via `Mailjet.Api` 3.0.1 → `NETStandard.Library` 1.6.1.
+
+> **Correction.** This was initially recorded as "no fix available, 3.0.1 is the latest Mailjet.Api".
+> That was wrong — it came from a query scoped to major version 3. **`Mailjet.Api` 4.0.1 exists**, and
+> Dependabot raised it as soon as version updates were enabled.
+
+`Mailjet.Api` 4.0.1 targets `netstandard2.0` and depends only on `Microsoft.CSharp` 4.7.0 and
+`Newtonsoft.Json` 13.0.4 — it drops `NETStandard.Library` entirely. Verified locally: the web project
+builds clean against 4.0.1 and `dotnet list package --vulnerable --include-transitive` then reports
+**no vulnerable packages at all**.
+
+Remaining work before taking it: 4.x is a major version bump. The existing call sites in
+`LB.PhotoGalleries/Services/NotificationService.cs` (`MailjetClient`, `MailjetRequest`, `Send.Resource`,
+`GetErrorMessage()`) all still compile, but **email sending has not been exercised at runtime** — smoke
+test notification emails before deploying.
 
 ### Deliberately held back
 
@@ -333,12 +344,20 @@ against a live Cosmos instance.
 - Rate limiting deferred - current traffic volume doesn't warrant implementation
 - Upload size limits kept at 100MB - appropriate for professional photography use case
 - ⚠️ "No known CVEs in current dependencies" was recorded on 2025-01-23 but is no longer accurate. As of
-  2026-08-08 two **High** severity transitive advisories remain via `Mailjet.Api` → `NETStandard.Library`,
-  with no upgrade path available. See the 2026-08-08 dependency update pass above.
+  2026-08-08 two **High** severity transitive advisories remain via `Mailjet.Api` → `NETStandard.Library`.
+  `Mailjet.Api` 4.0.1 resolves both. See the 2026-08-08 dependency update pass above.
 - Dependabot version updates were not enabled until 2026-08-08; only security updates ran before then,
-  which is why dependencies drifted between reviews
+  which is why dependencies drifted between reviews. Enabling them immediately surfaced the Mailjet 4.x
+  upgrade that a manual review had missed — worth remembering the next time a dependency is written off
+  as having no upgrade path.
+- CodeQL was in `disabled_inactivity` state and had not run since 2025-11-23. Re-enabled 2026-08-08; its
+  first successful scan raised 14 alerts (6 high, 8 medium), 11 of them in vendored `wwwroot/lib`
+  JavaScript. See below.
+- ⚠️ `wwwroot/lib` front-end libraries have **no update mechanism at all** — no `package.json`, hand-copied
+  in, invisible to Dependabot. `moment.js` is also deprecated upstream. This is the largest remaining
+  unmanaged dependency surface.
 - .NET 10 upgrade is the next significant piece of framework work, and now gates the Azure.Storage,
-  Serilog.AspNetCore and Microsoft.Extensions package updates
+  Serilog.AspNetCore and Microsoft.Extensions package updates. .NET 9 (STS) support ends 2026-11-10.
 - Application shows good engineering practices overall
-- Remaining work: .NET 10 upgrade, stale CI workflow actions, low-priority technical debt and
-  architectural improvements
+- Remaining work: `Mailjet.Api` 4.x, .NET 10 upgrade, vendored front-end libraries, CodeQL alert triage,
+  low-priority technical debt and architectural improvements


### PR DESCRIPTION
Follow-up to #70/#71, driven by what the first Dependabot run actually produced.

## 1. The grouped PR fails, exactly as predicted

#73 bundles the four packages the update pass deliberately held back, and CI failed with the expected NU1605:

```
NU1605: Detected package downgrade: Microsoft.Extensions.Configuration.Abstractions from 10.0.3 to 9.0.18
  ImageCommentCounter -> Microsoft.Azure.Cosmos 3.62.1 -> Azure.Core 1.55.0 -> ...Abstractions (>= 10.0.3)
```

Left alone this recurs weekly, and a dependency bot whose PRs always fail is one people stop reading — which defeats the point of turning it on.

## 2. A green PR that shouldn't be merged

#75 (`Microsoft.ApplicationInsights.AspNetCore` 3.1.2) is the more dangerous case. `Serilog.Sinks.ApplicationInsights` 5.0.1 requires `>= 2.23.0 && < 3.0.0`, but that mismatch surfaces as **NU1608 — a warning, not an error**. So it can pass CI while leaving a real runtime incompatibility. Now suppressed too.

## The ignore approach

Every entry ignores **semver-minor or semver-major only**, never the whole package:

| Package | Suppressed | Still raises PRs | Remove when |
|---|---|---|---|
| `Azure.Storage.Blobs` / `.Queues` | minor | 12.26.x / 12.24.x patches | moving to net10.0 |
| `Imageflow.Net` | minor | 0.14.x patches | smoke-tested |
| `Spectre.Console` | minor | 0.54.x patches | smoke-tested |
| `Microsoft.ApplicationInsights.AspNetCore` | major | 2.23.x patches | Serilog sink supports AI 3.x |

This matters because **Dependabot ignore conditions apply to security updates, not just version updates**. A blanket `dependency-name` ignore would have created a real blind spot — precisely the kind of gap that let things drift in the first place.

## 3. Correcting a wrong finding in #70 ⚠️

#70 recorded the two remaining High advisories (`System.Net.Http`, `System.Text.RegularExpressions` @ 4.3.0) as having **no upgrade path**, on the basis that `Mailjet.Api` 3.0.1 was the latest release.

**That was wrong.** It came from a query scoped to major version 3. `Mailjet.Api` **4.0.1** exists — and Dependabot raised it as #74 within minutes of version updates being enabled.

| | 3.0.1 (current) | 4.0.1 |
|---|---|---|
| Target | `netstandard1.1` | `netstandard2.0` |
| Deps | **`NETStandard.Library` 1.6.1**, `Newtonsoft.Json` 13.0.1 | `Microsoft.CSharp` 4.7.0, `Newtonsoft.Json` 13.0.4 |

It drops `NETStandard.Library` entirely, which is the source of both advisories. **Verified locally: the web project builds clean against 4.0.1, and `dotnet list package --vulnerable --include-transitive` then reports no vulnerable packages at all.**

`SECURITY-CHECKLIST.md` is corrected here. The fix itself is #74 — not folded in, because it's a major bump and email sending hasn't been exercised at runtime. Smoke test notification emails before deploying it.

Also records two findings from re-enabling CodeQL: the 14 alerts from its first successful scan, and that `wwwroot/lib` has **no update mechanism at all** — no `package.json`, hand-copied, invisible to Dependabot, with `moment.js` deprecated upstream.

## Suggested disposition of the open Dependabot PRs

| PR | Action |
|---|---|
| **#74** Mailjet 4.0.1 | **Merge** after smoke-testing email — clears the last 2 High advisories |
| **#75** App Insights 3.1.2 | **Close** — incompatible with the Serilog sink; suppressed by this PR |
| **#73** grouped minor/patch | **Close** — will stop being raised once this merges |
| **#72** grouped actions | **Close** — already conflicting; proposes the bumps merged in #71 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)