### PR TITLE
Add CodeQL config excluding vendored and build-output paths

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+name: "PhotoGalleries CodeQL config"
+
+# Exclude code we do not author from analysis. The first successful scan after
+# re-enabling CodeQL raised 14 alerts, 11 of which were in vendored third-party
+# JavaScript under wwwroot/lib. That volume buries findings in our own code,
+# which is the opposite of useful.
+#
+# Excluding these does NOT make them safe. wwwroot/lib has no update mechanism
+# at all - no package.json, hand-copied files, invisible to Dependabot, and
+# moment.js is deprecated upstream. That is tracked separately in
+# SECURITY-CHECKLIST.md and needs solving on its own terms, not by scanning.
+paths-ignore:
+  - LB.PhotoGalleries/wwwroot/lib
+
+  # Build output. CodeQL analysed bin/Debug/net9.0/web.config as if it were
+  # source, producing a duplicate of the alert already raised against the real
+  # LB.PhotoGalleries/web.config. These are gitignored but exist in the runner
+  # workspace after autobuild.
+  - "**/bin"
+  - "**/obj"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,6 +49,7 @@ jobs:
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Reduces scan noise so findings in code we own are actually visible. **This is the noise-reduction half of the CodeQL triage — the three real security findings it uncovered are listed below and are NOT fixed here.**

## What's excluded

| Path | Why |
|---|---|
| `LB.PhotoGalleries/wwwroot/lib` | 11 of 14 alerts were in vendored third-party JS |
| `**/bin`, `**/obj` | autobuild produces `bin/Debug/net9.0/web.config` in the runner workspace, duplicating the alert against the real `web.config` |

Excluding these does **not** make them safe. `wwwroot/lib` has no update mechanism at all — no `package.json`, hand-copied files, invisible to Dependabot, `moment.js` deprecated upstream. Tracked in `SECURITY-CHECKLIST.md`; it needs solving on its own terms, not by scanning.

⚠️ `paths-ignore` is well defined for interpreted languages like JavaScript. Its effect on the **C# analysis is less certain**, so whether the duplicate `bin/` alert actually disappears needs confirming against the next scan rather than assuming.

## Triage results — 3 real, 5 not

Full triage of the 8 C# alerts:

### Real, needs fixing (separate PR)

| # | Finding | Assessment |
|---|---|---|
| **87** | `Areas/Admin/Controllers/ImagesController.Upload` — POST without `[ValidateAntiForgeryToken]` | **Real.** `AddAntiforgery()` only sets the header name; it does not auto-validate, and the only global filter is `AuthorizeFilter`. ⚠️ Adding the attribute alone **would break the uploader** — `site.js` attaches `X-CSRF-TOKEN` via `$.ajaxSetup`, which covers jQuery AJAX only, and Dropzone uses raw XHR with no `headers` config. Needs a matching JS change. |
| **88** | `AccountController.EmailPreferences` — POST without `[ValidateAntiForgeryToken]` | **Real, and a safe one-line fix.** The view uses `Html.BeginForm()`, which already emits `__RequestVerificationToken`. Low impact (flips a notification preference). |
| **90** | `web.config` missing `X-Frame-Options` | **Real.** Confirmed no security-headers middleware in `Startup.cs` — only `UseHsts()`. The app genuinely does not send it, so there's clickjacking exposure. |

Worth noting #87 and #88 sit outside what `SECURITY-CHECKLIST.md` claimed. That entry says "All **API** POST, PUT, DELETE endpoints protected" — accurate as written, but both gaps are **MVC** controllers, which the sweep never covered. 34 `[ValidateAntiForgeryToken]` attributes against 36 POST/PUT/DELETE actions; CodeQL found exactly the 2.

### False positives

| # | Finding | Why it's a FP |
|---|---|---|
| **86** | `cs/user-controlled-bypass`, `Api/ImagesController.cs:289` | Line 289 is `if (!tags.Contains(',')) return BadRequest(...)` — input validation, not a security guard. Real authorisation (`CanUserEditObject`) happens after and isn't user-controlled. |
| **21, 26, 27** | `cs/web/xss` in three views | All are `asp-route-returnUrl="@Context.Request.Path"`. Razor tag helpers URL-encode route values. Also checked the sink: `HomeController.SignIn` uses `LocalRedirect()`, which throws on non-local URLs — so no open redirect either. |
| **89** | duplicate `X-Frame-Options` on `bin/` copy | Build artifact; excluded by this PR. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)