### PR TITLE
Fix two CSRF gaps and add security headers

### DIFF
--- a/LB.PhotoGalleries/Areas/Admin/Controllers/ImagesController.cs
+++ b/LB.PhotoGalleries/Areas/Admin/Controllers/ImagesController.cs
@@ -25,6 +25,7 @@ namespace LB.PhotoGalleries.Areas.Admin.Controllers
         #endregion
 
         [HttpPost]
+        [ValidateAntiForgeryToken]
         [RequestSizeLimit(104857600)]
         [RequestFormLimits(MultipartBodyLengthLimit = 104857600)]
         public async Task<IActionResult> Upload(string categoryId, string galleryId, IFormFile file)

--- a/LB.PhotoGalleries/Areas/Admin/Views/Galleries/Edit.cshtml
+++ b/LB.PhotoGalleries/Areas/Admin/Views/Galleries/Edit.cshtml
@@ -803,6 +803,10 @@
             paramName: "file",
             maxFilesize: 50,
             acceptedFiles: "image/*,.jpg,.jpeg,.png,/gif",
+            // Dropzone uses XMLHttpRequest directly, so the $.ajaxSetup handler in site.js that adds
+            // the anti-forgery token to jQuery AJAX calls does not apply here. The Upload action is
+            // [ValidateAntiForgeryToken], so the header has to be set explicitly or uploads 400.
+            headers: { 'X-CSRF-TOKEN': $('input[name="__RequestVerificationToken"]').val() },
             init: function() {
                 this.on("addedfile",
                     function() {

--- a/LB.PhotoGalleries/Controllers/AccountController.cs
+++ b/LB.PhotoGalleries/Controllers/AccountController.cs
@@ -29,6 +29,7 @@ public class AccountController : Controller
 
     [Route("/account/email-preferences")]
     [HttpPost]
+    [ValidateAntiForgeryToken]
     public async Task<IActionResult> EmailPreferences(EmailPreferencesModel emailPreferencesModel)
     {
         var user = await Server.Instance.Users.GetUserAsync(Helpers.GetUserId(User));

--- a/LB.PhotoGalleries/Startup.cs
+++ b/LB.PhotoGalleries/Startup.cs
@@ -174,6 +174,25 @@ public class Startup
             app.UseHsts();
         }
 
+        // security headers, applied to every response including static files and ImageFlow output.
+        // set before the rest of the pipeline runs so they're present when the response starts.
+        app.Use(async (context, next) =>
+        {
+            var headers = context.Response.Headers;
+
+            // prevent other origins framing the site (clickjacking). SAMEORIGIN rather than DENY so
+            // our own pages can still frame each other if needed.
+            headers["X-Frame-Options"] = "SAMEORIGIN";
+
+            // stop browsers MIME-sniffing a response away from its declared content type
+            headers["X-Content-Type-Options"] = "nosniff";
+
+            // don't leak full urls to third parties via the referer header
+            headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+            await next();
+        });
+
         app.UseHttpsRedirection();
 
         // configure ImageFlow for image resizing and serving

--- a/LB.PhotoGalleries/web.config
+++ b/LB.PhotoGalleries/web.config
@@ -7,6 +7,17 @@
         <requestLimits maxAllowedContentLength="104857600" />
       </requestFiltering>
     </security>
+
+    <!-- Security headers for IIS parity. These are also set by middleware in Startup.cs, which is
+         what actually applies in production: the app is deployed to a Linux VPS behind Kestrel,
+         where this file is inert. Kept in step with the middleware so both hosting models match. -->
+    <httpProtocol>
+      <customHeaders>
+        <add name="X-Frame-Options" value="SAMEORIGIN" />
+        <add name="X-Content-Type-Options" value="nosniff" />
+        <add name="Referrer-Policy" value="strict-origin-when-cross-origin" />
+      </customHeaders>
+    </httpProtocol>
   </system.webServer>
 
 </configuration>

--- a/SECURITY-CHECKLIST.md
+++ b/SECURITY-CHECKLIST.md
@@ -79,6 +79,10 @@ This document tracks security issues, dependency updates, and technical improvem
   - Tokens included in all pages via @Html.AntiForgeryToken() in layouts
   - jQuery configured to automatically send X-CSRF-TOKEN header with all AJAX requests
   - All API POST, PUT, DELETE endpoints protected with [ValidateAntiForgeryToken]
+  - ⚠️ **This sweep covered API controllers only.** CodeQL later found two unprotected POST endpoints
+    in **MVC** controllers that it never reached — `AccountController.EmailPreferences` and
+    `Areas/Admin/Controllers/ImagesController.Upload`. Both fixed 2026-08-08, see below. The original
+    statement was accurate as written but read as broader coverage than it had.
 
 - [x] **Fix Comment Deletion Integrity**
   - Location: `LB.PhotoGalleries/Controllers/API/ImagesController.cs:204-238` and `LB.PhotoGalleries/Controllers/API/GalleriesController.cs:34-60`
@@ -150,6 +154,54 @@ This document tracks security issues, dependency updates, and technical improvem
   - [x] `Microsoft.AspNetCore.Session` — reference removed entirely 2026-08-08. Session ships in the
         `Microsoft.AspNetCore.App` shared framework on net9.0, so the legacy netstandard2.0 package was
         redundant. `AddSession()`/`UseSession()` resolve without it.
+
+## 🔍 CODEQL TRIAGE — 2026-08-08
+
+CodeQL had been in `disabled_inactivity` state since 2025-11-23 and was re-enabled during the dependency
+pass. Its first successful scan raised 14 alerts. Full triage: **3 real, 11 noise.**
+
+### Fixed
+
+- [x] **Add CSRF protection to `AccountController.EmailPreferences`** (POST)
+  - Added `[ValidateAntiForgeryToken]`. The view already emitted the token via `Html.BeginForm()`, so
+    no view change was needed.
+  - Impact was low — an attacker could flip a victim's comment-notification preference.
+
+- [x] **Add CSRF protection to `Areas/Admin/Controllers/ImagesController.Upload`** (POST)
+  - Added `[ValidateAntiForgeryToken]`, **plus a matching `headers` entry in the Dropzone config** in
+    `Areas/Admin/Views/Galleries/Edit.cshtml`.
+  - ⚠️ **The two changes are inseparable.** `site.js` attaches `X-CSRF-TOKEN` through `$.ajaxSetup`,
+    which covers jQuery AJAX only. Dropzone uses `XMLHttpRequest` directly, so adding the attribute
+    on its own would have made every admin image upload fail with a 400. Anyone reverting one of
+    these must revert both.
+  - Root cause of the gap: the original CSRF sweep covered API controllers, and this is an MVC
+    controller in an Area.
+
+- [x] **Add security headers** — `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`,
+      `Referrer-Policy: strict-origin-when-cross-origin`
+  - Implemented as middleware in `Startup.cs`, placed before `UseHttpsRedirection()` so it covers
+    static files and ImageFlow output as well as MVC responses. `Startup.cs` previously had no
+    security headers at all beyond `UseHsts()`, so the site was framable.
+  - Also added to `web.config` for IIS parity. Note **`web.config` is inert in production** — the app
+    runs behind Kestrel on a Linux VPS — so the middleware is the functional fix. The duplication
+    exists because the CodeQL rule inspects `web.config` specifically.
+  - `SAMEORIGIN` rather than `DENY`, so our own pages can still frame each other.
+  - Content-Security-Policy deliberately **not** added: the views carry a lot of inline script and a
+    CSP strict enough to be worth having would break them. Worth doing as its own piece of work.
+
+### Dismissed as false positives
+
+| Alert | Rule | Why |
+|---|---|---|
+| #86 | `cs/user-controlled-bypass` | `Api/ImagesController.cs:289` is `if (!tags.Contains(',')) return BadRequest(...)` — input validation, not a security guard. Real authorisation (`CanUserEditObject`) happens afterwards and is not user-controlled. |
+| #21, #26, #27 | `cs/web/xss` | All three are `asp-route-returnUrl="@Context.Request.Path"`. Razor tag helpers URL-encode route values. The sink was also checked: `HomeController.SignIn` uses `LocalRedirect()`, which throws on non-local URLs, so there is no open redirect either. |
+| #89 | `cs/web/missing-x-frame-options` | Duplicate raised against `bin/Debug/net9.0/web.config`, a build artifact. |
+| 11 JS alerts | various | All in vendored `wwwroot/lib` third-party code. |
+
+### Scan configuration
+
+`.github/codeql/codeql-config.yml` excludes `wwwroot/lib`, `**/bin` and `**/obj`. Excluding the vendored
+JavaScript does **not** make it safe — see the front-end library note in TRACKING below.
 
 ## 📦 DEPENDENCY UPDATE PASS — 2026-08-08
 
@@ -363,5 +415,5 @@ against a live Cosmos instance.
 - .NET 10 upgrade is the next significant piece of framework work, and now gates the Azure.Storage,
   Serilog.AspNetCore and Microsoft.Extensions package updates. .NET 9 (STS) support ends 2026-11-10.
 - Application shows good engineering practices overall
-- Remaining work: .NET 10 upgrade, vendored front-end libraries, CodeQL alert triage, low-priority
+- Remaining work: .NET 10 upgrade, vendored front-end libraries, low-priority
   technical debt and architectural improvements


### PR DESCRIPTION
The three real findings from the CodeQL triage (full triage in #77). The other 11 alerts were false positives or vendored third-party JS.

## 1. Two unprotected POST endpoints

`AccountController.EmailPreferences` and `Areas/Admin/Controllers/ImagesController.Upload` both handled POST without `[ValidateAntiForgeryToken]`.

Verified nothing else was covering them: `AddAntiforgery()` only sets the header name — it does **not** auto-validate — and the only global filter registered is `AuthorizeFilter`. 34 `[ValidateAntiForgeryToken]` attributes against 36 POST/PUT/DELETE actions, and CodeQL found exactly the 2.

The earlier CSRF sweep recorded in `SECURITY-CHECKLIST.md` covered **API** controllers. Both gaps are **MVC** controllers, which it never reached.

### ⚠️ The Upload fix is two inseparable changes

`site.js` attaches `X-CSRF-TOKEN` through `$.ajaxSetup` — **jQuery AJAX only**. Dropzone uses `XMLHttpRequest` directly, so adding the attribute on its own would have made **every admin image upload fail with a 400**.

So this PR changes both the controller and the Dropzone config in `Areas/Admin/Views/Galleries/Edit.cshtml`. **Anyone reverting one must revert both.** Confirmed the token is available: the admin `_ViewStart` sets `_Layout`, which emits `@Html.AntiForgeryToken()` in `<head>`, well before the Dropzone script at the bottom of the page.

`EmailPreferences` needed no view change — `Html.BeginForm()` already emits the token.

## 2. No security headers

`Startup.cs` had none beyond `UseHsts()`, so the site was framable. Added as middleware:

- `X-Frame-Options: SAMEORIGIN` — `SAMEORIGIN` not `DENY`, so our own pages can still frame each other
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

Placed before `UseHttpsRedirection()` so it covers static files and ImageFlow output, not just MVC responses.

Also mirrored into `web.config`. Worth being clear about why: **`web.config` is inert in production** — the app runs behind Kestrel on a Linux VPS — so the middleware is the functional fix. The duplication exists for IIS parity and because the CodeQL rule inspects `web.config` specifically.

**Content-Security-Policy deliberately not added.** The views carry a lot of inline script, and a CSP strict enough to be worth having would break them. That deserves its own piece of work rather than being smuggled in here.

## Verification

Release build 0 errors · 6/6 tests pass.

⚠️ **The admin uploader cannot be exercised locally.** Please upload an image via the admin gallery editor on TEST after this deploys — that's the one path with real breakage risk, and a 400 on upload is the symptom to watch for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)